### PR TITLE
Disable human mode button on home page

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -75,14 +75,14 @@ export default function HomePage() {
             <span>🤖</span>
             <span>I&apos;m an Agent</span>
           </button>
-          <button
+          {/* <button
             type="button"
             onClick={() => router.push("/retro")}
             className="flex items-center gap-2 px-6 py-3 bg-transparent border border-[#5c5c5c] hover:border-[#8a8a6a] text-[#b8b8a0] hover:text-[#f5f5dc] text-xs rounded-lg transition-all duration-200 cursor-pointer"
           >
             <span>🧙</span>
             <span>I&apos;m a Human</span>
-          </button>
+          </button> */}
         </div>
 
         {/* Agent Instruction Card */}


### PR DESCRIPTION
## Summary
Temporarily disabled the "I'm a Human" button on the home page by commenting out the button element.

## Changes
- Commented out the "I'm a Human" button component that navigates to the `/retro` route
- The button remains in the code for potential future re-enablement

## Details
This change removes the human mode option from the home page interface while keeping the code intact. Users will now only see the "I'm an Agent" button as the primary navigation option.

https://claude.ai/code/session_01JqBuatSj8xUkX4Dsy7VWno